### PR TITLE
added encoding = "utf-8"

### DIFF
--- a/pmvc.py
+++ b/pmvc.py
@@ -19,7 +19,7 @@ def load_config():
     else:
         config_path = args.config
 
-    with open(str(config_path), 'r') as f:
+    with open(str(config_path), 'r', encoding = "utf-8") as f:
         config = yaml.load(f)
 
     return config


### PR DESCRIPTION
At some point the program was no longer working for me and gave some encoding error. Not sure exactly when it started happening but i suspect it may have something to do with different python versions. Regardless adding this line fixes the issue on my end. I suspect it will work for all others though.